### PR TITLE
Make devops parameter along with cluster

### DIFF
--- a/src/pages/devops/components/Pipeline/store.js
+++ b/src/pages/devops/components/Pipeline/store.js
@@ -377,7 +377,8 @@ export default class Store extends BaseStore {
   async fetchLabel({ devops, cluster }) {
     const url = `${this.getDevopsUrlV2({
       cluster,
-    })}devops/${devops}/jenkins/labelsdashboard/labelsData`
+      devops,
+    })}jenkins/labelsdashboard/labelsData`
 
     const result = await request.get(url, {}, {}, () => {
       this.labelDataList = []


### PR DESCRIPTION
### What this PR dose?

Make devops parameter along with cluster. According to https://github.com/kubesphere/console/pull/2434#discussion_r726703772.

It works well (docker image for test: `johnniang/ks-console:fix-api-labelsdata-dev`), please see:

![image](https://user-images.githubusercontent.com/16865714/136886304-998f1721-7acf-4640-8806-583802bb2472.png)
